### PR TITLE
View permission for selected users

### DIFF
--- a/ckanext/bostonschema/helpers.py
+++ b/ckanext/bostonschema/helpers.py
@@ -1,0 +1,10 @@
+from ckanapi import LocalCKAN
+
+def nonsysadmin_user_choices(field):
+    """
+    Return the non-sysadmin users as a choice list
+    """
+    lc = LocalCKAN(username='')
+    return [
+        {'value': u['id'], 'label': u['display_name']}
+        for u in lc.action.user_list() if not u['sysadmin']]

--- a/ckanext/bostonschema/plugins.py
+++ b/ckanext/bostonschema/plugins.py
@@ -1,8 +1,11 @@
+from ckanext.bostonschema import helpers
 
-from ckan.plugins import toolkit, IConfigurer, SingletonPlugin, implements
+from ckan.plugins import (toolkit, IConfigurer, SingletonPlugin, implements,
+    ITemplateHelpers)
 
 class BostonSchema(SingletonPlugin):
     implements(IConfigurer)
+    implements(ITemplateHelpers)
 
     def update_config(self, config):
         toolkit.add_template_directory(config, "templates")
@@ -17,3 +20,5 @@ ckanext.bostonschema:schemas/presets.yaml
 ckanext.bostonschema:schemas/dataset.yaml
 """
 
+    def get_helpers(self):
+        return {'nonsysadmin_user_choices': helpers.nonsysadmin_user_choices}

--- a/ckanext/bostonschema/plugins.py
+++ b/ckanext/bostonschema/plugins.py
@@ -1,11 +1,15 @@
+import json
+
 from ckanext.bostonschema import helpers
 
 from ckan.plugins import (toolkit, IConfigurer, SingletonPlugin, implements,
-    ITemplateHelpers)
+    ITemplateHelpers, IPermissionLabels)
+from ckan.lib.plugins import DefaultPermissionLabels
 
-class BostonSchema(SingletonPlugin):
+class BostonSchema(SingletonPlugin, DefaultPermissionLabels):
     implements(IConfigurer)
     implements(ITemplateHelpers)
+    implements(IPermissionLabels)
 
     def update_config(self, config):
         toolkit.add_template_directory(config, "templates")
@@ -22,3 +26,14 @@ ckanext.bostonschema:schemas/dataset.yaml
 
     def get_helpers(self):
         return {'nonsysadmin_user_choices': helpers.nonsysadmin_user_choices}
+
+    def get_dataset_labels(self, dataset_obj):
+        view_users = json.loads(dataset_obj.extras.get('view_users', '[]'))
+        labels = super(BostonSchema, self).get_dataset_labels(dataset_obj)
+        return labels + [u'view-%s' % u for u in view_users]
+
+    def get_user_dataset_labels(self, user_obj):
+        labels = super(BostonSchema, self).get_user_dataset_labels(user_obj)
+        if user_obj:
+            labels.append(u'view-%s' % user_obj.id)
+        return labels

--- a/ckanext/bostonschema/schemas/dataset.yaml
+++ b/ckanext/bostonschema/schemas/dataset.yaml
@@ -429,6 +429,13 @@ dataset_fields:
 #  display_snippet: email.html
 #  display_email_name_field: maintainer
 
+##
+#  extra view-only permission on this dataset for users selected here
+- field_name: view_users
+  label: View Permissions
+  preset: multiple_select
+  choices_helper: nonsysadmin_user_choices
+
 
 ## "Distribution" fields
 resource_fields:

--- a/ckanext/bostonschema/schemas/dataset.yaml
+++ b/ckanext/bostonschema/schemas/dataset.yaml
@@ -435,6 +435,7 @@ dataset_fields:
   label: View Permissions
   preset: multiple_select
   choices_helper: nonsysadmin_user_choices
+  display_snippet: null
 
 
 ## "Distribution" fields


### PR DESCRIPTION
This PR adds a view_users field to the dataset schema that lets those extra users view private datasets. It requires the IPermissionLabels feature from https://github.com/ckan/ckan/pull/3192. We either need to backport those changes to our CKAN or start running the latest master until the 2.7 release is available