### PR TITLE
Revert "added govent, contact"

### DIFF
--- a/ckanext/bostonschema/schemas/dataset.yaml
+++ b/ckanext/bostonschema/schemas/dataset.yaml
@@ -364,7 +364,6 @@ dataset_fields:
   - Boston Transportation Department
   - Boston Water and Sewer Commission
   - BPDA Management Information Systems
-  - BRJP Manager
   - City of Boston Archaeology Program
   - Climate and Buildings Program Manager
   - Data Literacy Librarian, Boston Open Data

--- a/ckanext/bostonschema/schemas/presets.yaml
+++ b/ckanext/bostonschema/schemas/presets.yaml
@@ -177,8 +177,6 @@ presets:
       value: BPDA contract compliance database
     - label: BRA pipeline database
       value: BRA pipeline database
-    - label: BRJP Manager
-      value: BRJP Manager
     - label: City Clerk documents and assigned docket numbers
       value: City Clerk documents and assigned docket numbers
     - label: City Constituent Relationship Management (CRM) System


### PR DESCRIPTION
Reverts OpenGov-OpenData/ckanext-bostonschema#5

BRJP Manager was added to source_choices in presets.yaml. For BRJP Manager to appear in the Contact Point it should be added to government_entity_choices in presets.yaml.