### PR TITLE
[ES-4391] Add Boston Maps and External Organization to publisher field

### DIFF
--- a/ckanext/bostonschema/schemas/dataset.yaml
+++ b/ckanext/bostonschema/schemas/dataset.yaml
@@ -124,8 +124,10 @@ dataset_fields:
   form_restrict_choices_to:
   - Department of Innovation and Technology
   - Assessing Department
+  - Boston Maps
   - Boston Water and Sewer Commission
   - City of Boston
+  - External Organization
 
 ## "classification"
 #  Exempt/Public

--- a/ckanext/bostonschema/schemas/presets.yaml
+++ b/ckanext/bostonschema/schemas/presets.yaml
@@ -35,6 +35,8 @@ presets:
       value: Boston EMS
     - label: Boston Fire Department
       value: Boston Fire Department
+    - label: Boston Maps
+      value: Boston Maps
     - label: Boston Planning & Development Agency
       value: Boston Planning and Development Agency
     - label: Boston Police Department
@@ -93,6 +95,8 @@ presets:
       value: Environment, energy, and open space
     - label: Environment Department
       value: Environment Department
+    - label: External Organization
+      value: External Organization
     - label: Fair Housing & Equity
       value: Fair Housing and Equity
     - label: Finance, budget, & administration


### PR DESCRIPTION
## Descritpion
This PR adds `Boston Maps` and `External Organization` to the publisher field in Boston's dataset schema.

## Testing
- Install the boston schema extension along with required extensions [ckanext-scheming](https://github.com/OpenGov-OpenData/ckanext-scheming) and [ckanext-fluent](https://github.com/ckan/ckanext-fluent).
- In the dataset edit page, verify that the values `Boston Maps` and `External Organization` appear in the publisher field