### PR TITLE
[ESN-217] Add Analytics Team to contact point

### DIFF
--- a/ckanext/bostonschema/schemas/dataset.yaml
+++ b/ckanext/bostonschema/schemas/dataset.yaml
@@ -311,6 +311,7 @@ dataset_fields:
   # only show some government entities
   form_restrict_choices_to:
   - Department of Innovation and Technology
+  - Analytics Team
   - Archives and Records Management
   - Assessing Department
   - Assistant Director of Operations, Consumer Affairs and Licensing
@@ -438,7 +439,7 @@ resource_fields:
 - field_name: name_translated
   label: Title
   preset: fluent_text
-  form_placeholder: eg. January 2011 Gold Prices
+  form_placeholder: eg. January 2015 Gold Prices
 
 ## "description"
 #  core CKAN field

--- a/ckanext/bostonschema/schemas/presets.yaml
+++ b/ckanext/bostonschema/schemas/presets.yaml
@@ -19,6 +19,8 @@ presets:
       value: Department of Innovation and Technology
     - label: Administration & Finance
       value: Administration and Finance
+    - label: Analytics Team
+      value: Analytics Team
     - label: Archives and Records Management
       value: Archives and Records Management
     - label: Arts & Culture


### PR DESCRIPTION
## [Ticket](https://opengovinc.atlassian.net/browse/ESN-217)

## Description
This PR adds `Analytics Team` to the contact point field.

## Testing
- Install this PR and the [ckanext-scheming](https://github.com/OpenGov/ckanext-scheming/) extension
- Restart CKAN and navigate to the create dataset page
- The value `Analytics Team` should appear in the contact point dropdown menu