### PR TITLE
[ESN-1996] Added new contact points

### DIFF
--- a/ckanext/bostonschema/schemas/dataset.yaml
+++ b/ckanext/bostonschema/schemas/dataset.yaml
@@ -318,6 +318,7 @@ dataset_fields:
   - Boston 311
   - Boston Centers for Youth and Families
   - Boston EMS
+  - Boston Licensing Board
   - Boston Planning and Development Agency
   - Boston Police Department
   - Boston Public Library
@@ -327,6 +328,7 @@ dataset_fields:
   - BRJP Manager
   - City of Boston Archaeology Program
   - Climate and Buildings Program Manager
+  - Consumer Licensing and Affairs
   - Data Literacy Librarian, Boston Open Data
   - Deputy Director, Real Estate Management and Sales
   - Director of Publicity, Inspectional Services Department

--- a/ckanext/bostonschema/schemas/presets.yaml
+++ b/ckanext/bostonschema/schemas/presets.yaml
@@ -39,6 +39,8 @@ presets:
       value: Boston Fire Department
     - label: Boston Maps
       value: Boston Maps
+    - label: Boston Licensing Board
+      value: Boston Licensing Board
     - label: Boston Planning & Development Agency
       value: Boston Planning and Development Agency
     - label: Boston Police Department
@@ -71,6 +73,8 @@ presets:
       value: Climate and Buildings Program Manager
     - label: Consumer Affairs & Licensing Department
       value: Consumer Affairs and Licensing Department
+    - label: Consumer Licensing and Affairs
+      value: Consumer Licensing and Affairs
     - label: Data Literacy Librarian, Boston Open Data
       value: Data Literacy Librarian, Boston Open Data
     - label: Department of Neighborhood Development


### PR DESCRIPTION
## [ESN-1996](https://opengovinc.atlassian.net/browse/ESN-1996)

## Description
This PR adds 2 new contact points that Boston has request:
 - Boston Licensing Board
 - Consumer Licensing and Affairs

## Testing
- Checkout this PR and enable the following plugins
```
spatial_metadata
spatial_query
boston_schema
scheming_datasets
fluent
```
- Restart CKAN and navigate to the create dataset page
- The value `Boston Licensing Board` and `Consumer Licensing and Affairs` should appear in the contact point dropdown menu